### PR TITLE
Add type stub target to MLIRPythonModules in CMakeLists.txt

### DIFF
--- a/python_bindings/CMakeLists.txt
+++ b/python_bindings/CMakeLists.txt
@@ -98,12 +98,16 @@ endif()
 # The fully assembled package of modules. This must come last.
 # ##############################################################################
 
+set(_declared_sources MLIRPythonSources MLIRPythonExtension.RegisterEverything)
+if(NOT CMAKE_CROSSCOMPILING)
+  list(APPEND _declared_sources MLIRPythonExtension.Core.type_stub_gen)
+endif()
+
 add_mlir_python_modules(MLIRPythonModules
   ROOT_PREFIX "${MLIR_BINARY_DIR}/mlir"
   INSTALL_PREFIX "mlir"
   DECLARED_SOURCES
-    MLIRPythonSources
-    MLIRPythonExtension.RegisterEverything
+    ${_declared_sources}
   COMMON_CAPI_LINK_LIBS
     MLIRPythonCAPI
 )


### PR DESCRIPTION
The current mlir-python-bindings packages have no generated pyi files inside. I think the reason may be that the type stubs generated by stubgen is missing from the CMake target.

This PR is trying to fix it.